### PR TITLE
Kernel thread support

### DIFF
--- a/notes/dir_layout.md
+++ b/notes/dir_layout.md
@@ -16,4 +16,5 @@
         - **drivers**: support for particular HW devices
 		- **mm**: physical and virtual memory management
 		- **nonstd**: imitating standard library code
+		- **sched**: kernel thread scheduling and synchronization
 		- **util**: miscellaneous utility functions

--- a/src/crt/crti.cc
+++ b/src/crt/crti.cc
@@ -37,7 +37,7 @@ void run_global_dtors() {
 
 extern "C" void __cxa_pure_virtual() {}
 
-extern "C" void *__dso_handle = 0;
+extern "C" void *__dso_handle /*=nullptr*/;
 
 namespace {
 

--- a/src/kernel/arch/x86/stack.S
+++ b/src/kernel/arch/x86/stack.S
@@ -1,0 +1,58 @@
+	.section .text
+
+	.globl switch_stack
+	.globl setup_stack
+
+switch_stack:
+	mov 0x8(%esp), %ecx	# new_stk
+	mov 0x4(%esp), %eax 	# &old_stk
+
+	# Old stack
+	push %ebx
+	push %ebp
+	push %edi
+	push %esi
+	mov %esp, (%eax)
+
+	# New stack
+	mov %ecx, %esp
+	pop %esi
+	pop %edi
+	pop %ebp
+	pop %ebx
+	ret
+
+setup_stack:
+	mov 0xc(%esp), %ecx	# kthread
+	mov 0x8(%esp), %eax	# thunk
+	mov %esp, %edx		# save the current stack pointer
+
+	# We're acting on the new stack now.
+	mov 0x4(%esp), %esp
+
+	# .Linit_thread(kthread, thunk)
+	push %eax
+	push %ecx
+	push $.Linit_thread 	# return address for switch_stack
+
+	push $0
+	push $0
+	push $0
+	push $0
+	mov %esp, %eax
+
+	# Return to old stack.
+	mov %edx, %esp
+	ret
+
+	## void .Linit_thread(KernelThread *kthread, void (*thunk)());
+	##
+	## Called at the start of each thread.
+.Linit_thread:
+	## on_thread_start(kthread, thunk)
+	call on_thread_start
+
+	pop %eax		# kthread
+	pop %eax		# thunk
+	push $0			# return address for `thunk`
+	jmp *%eax

--- a/src/kernel/arch/x86/stack.h
+++ b/src/kernel/arch/x86/stack.h
@@ -1,0 +1,28 @@
+#pragma once
+
+/// \file
+/// \brief Some asm functions to help perform thread switching.
+
+namespace sched {
+struct KernelThread;
+}
+
+namespace arch::sched {
+extern "C" {
+
+/// Switch stacks. This saves the old tasks's state (callee-save
+/// registers) on its stack, and restores the new task's state from
+/// its stack.
+///
+/// \a new_stk should either be set up from a previous call to \ref
+/// switch_stack() or from \ref setup_stack(). For this reason, it is
+/// not safe for \a new_stk to be the currently running thread.
+void switch_stack(void **old_stk, void *new_stk);
+
+/// Set up a stack that looks like a process that was scheduled-away
+/// from in \ref switch_stack().
+///
+/// \return the stack with the added stack frame
+void *setup_stack(void *stk, void (*thunk)(), ::sched::KernelThread *kthread);
+}
+} // namespace arch::sched

--- a/src/kernel/arch/x86/timer.h
+++ b/src/kernel/arch/x86/timer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+/// \file
+/// \brief Architecture-specific timing functions.
+
+#include <cstdint>
+
+namespace arch::time {
+
+/// Read the CPU's time-stamp counter.
+__attribute__((naked)) inline uint64_t rdtsc() {
+  __asm__ volatile("rdtsc\n\tret");
+}
+
+} // namespace arch::time

--- a/src/kernel/linker.ld
+++ b/src/kernel/linker.ld
@@ -22,9 +22,14 @@ SECTIONS
 	.bss : {
 		*(COMMON)
 		*(.bss)
+
+		/* Force .bss region in flat binary file for ld.
+		https://f.osdev.org/viewtopic.php?p=101868 */
+		LONG(0)
 	}
 
-	/* See https://stackoverflow.com/a/77339871 */
+	/* Force .bss region in flat binary file for lld.
+	See https://stackoverflow.com/a/77339871 */
 	.fake : {
 		. = . + SIZEOF(.bss);
 	}

--- a/src/kernel/mm/kmalloc.cc
+++ b/src/kernel/mm/kmalloc.cc
@@ -1,0 +1,53 @@
+#include "mm/kmalloc.h"
+#include "memdefs.h"
+#include "mm/page_frame_allocator.h"
+#include "mm/virt.h"
+#include "perf.h"
+#include "util/algorithm.h"
+
+namespace {
+void *arena = nullptr;
+mem::phys::SimplePFA *pfa = nullptr;
+}; // namespace
+
+namespace mem {
+
+void set_pfa(phys::SimplePFA *_pfa) { pfa = _pfa; }
+
+void *kmalloc(size_t sz) noexcept {
+  if (unlikely(pfa == nullptr)) {
+    return nullptr;
+  }
+
+  // Alloc new page(s) as needed.
+  if (!arena || ((size_t)arena & (PG_SZ - 1)) + sz > PG_SZ) {
+    auto page_frame = pfa->alloc(util::algorithm::ceil_pow2<PG_SZ>(sz) / PG_SZ);
+    arena = page_frame ? virt::direct_to_hhdm(*page_frame) : nullptr;
+  }
+
+  if (!arena) {
+    // OOM.
+    return nullptr;
+  }
+
+  void *obj = arena;
+  arena = (char *)arena + sz;
+  if (PG_ALIGNED((size_t)arena)) {
+    // We've reached the end of a page, and will have to alloc a new
+    // page on the next kmalloc() call.
+    arena = nullptr;
+  }
+  return obj;
+}
+
+void kfree(void *data) noexcept {
+  // nop
+}
+
+} // namespace mem
+
+void *operator new(size_t sz) { return ::operator new(sz, std::nothrow); }
+void *operator new(size_t sz, const std::nothrow_t &tag) noexcept {
+  return mem::kmalloc(sz);
+}
+void operator delete(void *ptr) noexcept { return mem::kfree(ptr); }

--- a/src/kernel/mm/kmalloc.cc
+++ b/src/kernel/mm/kmalloc.cc
@@ -51,3 +51,4 @@ void *operator new(size_t sz, const std::nothrow_t &tag) noexcept {
   return mem::kmalloc(sz);
 }
 void operator delete(void *ptr) noexcept { return mem::kfree(ptr); }
+void operator delete(void *ptr, size_t sz) noexcept { ::operator delete(ptr); }

--- a/src/kernel/mm/kmalloc.h
+++ b/src/kernel/mm/kmalloc.h
@@ -33,3 +33,4 @@ void kfree(void *data) noexcept;
 void *operator new(size_t sz);
 void *operator new(size_t sz, const std::nothrow_t &tag) noexcept;
 void operator delete(void *ptr) noexcept;
+void operator delete(void *ptr, size_t sz) noexcept;

--- a/src/kernel/mm/kmalloc.h
+++ b/src/kernel/mm/kmalloc.h
@@ -1,0 +1,35 @@
+#pragma once
+
+/// \file
+/// \brief Very simple sequential allocator.
+///
+/// Temporary helper functions before we have a slab allocator. Never
+/// frees memory. Maybe we can keep this around (or some version of a
+/// sequential allocator w/ vmalloc, so the entire arena is contiguous
+/// and can be freed at once) as a very simple allocator model.
+///
+/// TODO: rename this file to nonstd/new.h
+
+#include <new>
+#include <stddef.h>
+
+namespace mem {
+
+namespace phys {
+class SimplePFA;
+}
+void set_pfa(phys::SimplePFA *pfa);
+
+// These functions will return HHDM virtual addresses.
+void *kmalloc(size_t sz) noexcept;
+void kfree(void *data) noexcept;
+
+} // namespace mem
+
+// We don't have exceptions so this is actually equivalent to the
+// nothrow variant. If using the `new` operator, we'll immediately
+// page fault in this case due to attempting to run the constructor on
+// the null page.
+void *operator new(size_t sz);
+void *operator new(size_t sz, const std::nothrow_t &tag) noexcept;
+void operator delete(void *ptr) noexcept;

--- a/src/kernel/mm/kmalloc.h
+++ b/src/kernel/mm/kmalloc.h
@@ -8,7 +8,6 @@
 /// sequential allocator w/ vmalloc, so the entire arena is contiguous
 /// and can be freed at once) as a very simple allocator model.
 ///
-/// TODO: rename this file to nonstd/new.h
 
 #include <new>
 #include <stddef.h>

--- a/src/kernel/mm/virt.h
+++ b/src/kernel/mm/virt.h
@@ -13,7 +13,7 @@ namespace mem::virt {
 constexpr size_t hhdm_len = 1 * GB - KERNEL_MAP_SZ;
 constexpr size_t hhdm_start = HM_START;
 
-template <typename T> inline T *direct_to_hhdm(size_t phys_addr) {
+template <typename T = void> inline T *direct_to_hhdm(uint64_t phys_addr) {
   return reinterpret_cast<T *>(phys_addr + hhdm_start);
 }
 

--- a/src/kernel/nonstd/libc_symbols.cc
+++ b/src/kernel/nonstd/libc_symbols.cc
@@ -1,0 +1,14 @@
+/// \file
+/// \brief Symbols in the `std` namespace required by `std`
+/// interfaces. If they have a trivial implementation, they can be
+/// implemented here and we can use them instead of implementing a
+/// `nonstd` version.
+
+#include <new>
+
+////////////////////////////////////////////////////////////////////////////////
+// new.h
+////////////////////////////////////////////////////////////////////////////////
+namespace std {
+const std::nothrow_t nothrow{};
+}

--- a/src/kernel/nonstd/string_view.h
+++ b/src/kernel/nonstd/string_view.h
@@ -6,6 +6,7 @@
 
 #include "nonstd/libc.h"
 #include "perf.h"
+#include <algorithm>
 #include <cstddef>
 
 namespace nonstd {
@@ -21,8 +22,17 @@ public:
   constexpr size_t length() const { return _len; }
   constexpr size_t size() const { return _len; }
 
-  friend constexpr bool operator==(string_view lhs, string_view rhs) {
-    return lhs._len == rhs._len && !strncmp(lhs.data(), rhs.data(), lhs._len);
+  constexpr bool operator==(const string_view &rhs) const {
+    return _len == rhs._len && !strncmp(_data, rhs._data, _len);
+  }
+
+  constexpr auto operator<=>(const string_view &rhs) const {
+    const size_t cmp_len = std::min(_len, rhs._len);
+    const auto res = nonstd::strncmp(_data, rhs._data, cmp_len);
+    if (res != 0) {
+      return res <=> 0;
+    }
+    return _len <=> rhs._len;
   }
 
   static constexpr size_t npos = -1;

--- a/src/kernel/sched/kthread.cc
+++ b/src/kernel/sched/kthread.cc
@@ -1,0 +1,178 @@
+#include "sched/kthread.h"
+#include "memdefs.h"
+#include "mm/kmalloc.h"
+#include "nonstd/libc.h"
+#include "perf.h"
+#include "stack.h"
+#include "timer.h"
+#include "util/algorithm.h"
+#include "util/assert.h"
+
+namespace {
+
+/// Thread ID counter.
+unsigned _tid = 0;
+
+} // namespace
+
+namespace sched {
+
+KernelThread::KernelThread(Scheduler &_scheduler, void *_stack)
+    : stack{_stack}, scheduler(_scheduler), tid(_tid++) {}
+
+void Scheduler::bootstrap() {
+  // Can't call `bootstrap()` on an already-running scheduler.
+  ASSERT(running == nullptr);
+  running = new KernelThread(*this);
+  ASSERT(running != nullptr);
+
+  // TODO: add dummy runnable task so that something is always
+  // schedulable
+}
+
+void Scheduler::new_thread(void (*thunk)()) {
+  // Allocate a new stack, and set it up so that it looks like we've
+  // just called into `switch_task()` with the return address being
+  // the beginning of `f()`.
+
+  // TODO: use the PFA directly rather than malloc, since this should
+  // be page-aligned.
+  void *stk = ::operator new(PG_SZ);
+  ASSERT(stk != nullptr);
+
+  // Go to the top of the stack.
+  stk = (char *)stk + PG_SZ;
+
+  auto *thread = new KernelThread(*this);
+  thread->stack = arch::sched::setup_stack(stk, thunk, thread);
+
+  // Add thread to the end of the round-robin space.
+  runnable.push_back(*thread);
+
+  // TODO: Call `schedule()` here?
+}
+
+const KernelThread *Scheduler::choose_task() const {
+  ASSERT(running);
+
+  // Round-robin from the runnable list.
+  if (!runnable.empty()) {
+    return &*runnable.begin();
+  }
+
+  // Runnable list is empty, check if the current task is runnable.
+  if (running->runnable) {
+    return running;
+  }
+
+  // Nothing to schedule.
+  return nullptr;
+}
+
+void Scheduler::schedule() {
+  ASSERT(running);
+
+  KernelThread *new_task = const_cast<KernelThread *>(choose_task());
+  KernelThread *current_task = running;
+
+  // We should always be able to find a new task since there is a
+  // dummy (always-schedulable) task.
+  ASSERT(new_task);
+
+  if (new_task == current_task) {
+    // Nothing to do here.
+    return;
+  }
+
+  // Do all the bookkeeping here, before we switch stacks. We can't do
+  // this after switching stacks or else we'll be updating the
+  // bookkeeping from the `new_task's` last context switch.
+  //
+  // TODO: separate this out into a separate function for unit
+  // testing. or just don't call `switch_stack` in unit testing.
+  running = new_task;
+  new_task->erase();
+  runnable.push_back(*current_task);
+  context_switch_start = arch::time::rdtsc();
+
+  arch::sched::switch_stack(&current_task->stack, new_task->stack);
+
+  // We've swapped stacks now.
+  post_context_switch_bookkeeping();
+}
+
+void Scheduler::print_stats() const {
+  // Note: runnable.size() is slow.
+  nonstd::printf("scheduler stats:\r\n"
+                 "\tcontext switches: %u\r\n"
+                 "\tcycles/switch: %llu\r\n"
+                 "\trunnable count: %u\r\n",
+                 context_switch_count,
+                 context_switch_cum_cycles / context_switch_count,
+                 runnable.size());
+}
+
+void Scheduler::post_context_switch_bookkeeping() {
+  context_switch_cum_cycles += arch::time::rdtsc() - context_switch_start;
+  ++context_switch_count;
+
+  if (unlikely(pending_deletion)) {
+    delete_task(pending_deletion);
+    pending_deletion = nullptr;
+  }
+
+  if (unlikely(context_switch_count % 100 == 0)) {
+    print_stats();
+  }
+}
+
+void Scheduler::destroy_thread(KernelThread *thread) {
+  if (thread == nullptr) {
+    thread = running;
+  }
+
+  ASSERT(thread);
+  ASSERT(&thread->scheduler == this);
+
+  bool destroy_current = thread == running;
+  if (!destroy_current) {
+    // If we're not cleaning up the current thread, the process is
+    // relatively straightforward, and we can delete it right away.
+    // We also don't have to schedule away right away.
+    delete_task(thread);
+  } else {
+    // We can't safely deallocate the kernel thread and its
+    // resources before scheduling away, so let's mark it for
+    // deletion and clean it after the next call to `schedule()`.
+    thread->runnable = false;
+
+    // We should never have two threads pending deletion
+    // simultaneously.
+    ASSERT(pending_deletion == nullptr);
+    pending_deletion = thread;
+
+    schedule();
+  }
+}
+
+void Scheduler::delete_task(KernelThread *thread) {
+  ASSERT(thread);
+  ASSERT(&thread->scheduler == this);
+
+  thread->erase();
+
+  auto *stack_pg =
+      (void *)util::algorithm::floor_pow2<PG_SZ>((size_t)thread->stack);
+  mem::kfree(stack_pg);
+
+  mem::kfree(thread);
+}
+
+extern "C" {
+void on_thread_start(KernelThread *thread, void (*thunk)()) {
+  ASSERT(thread);
+  thread->scheduler.post_context_switch_bookkeeping();
+}
+}
+
+} // namespace sched

--- a/src/kernel/sched/kthread.cc
+++ b/src/kernel/sched/kthread.cc
@@ -131,7 +131,7 @@ void Scheduler::post_context_switch_bookkeeping() {
   }
 }
 
-void Scheduler::destroy_thread(KernelThread *thread) {
+void Scheduler::destroy_thread(KernelThread *thread, bool switch_stack) {
   if (thread == nullptr) {
     thread = running;
   }
@@ -156,7 +156,7 @@ void Scheduler::destroy_thread(KernelThread *thread) {
     ASSERT(pending_deletion == nullptr);
     pending_deletion = thread;
 
-    schedule();
+    schedule(switch_stack);
   }
 }
 

--- a/src/kernel/sched/kthread.h
+++ b/src/kernel/sched/kthread.h
@@ -1,0 +1,128 @@
+#pragma once
+
+/// \file
+/// \brief Kernel thread implementation
+///
+/// Each kernel thread gets a 4KB stack.
+///
+/// TODO: more description
+/// TODO: pre-emptive scheduling (timer interrupt) and synchronization
+/// primitives
+
+#include "util/intrusive_list.h"
+
+namespace sched {
+
+class Scheduler;
+struct KernelThread : public util::IntrusiveListHead<KernelThread> {
+  KernelThread(Scheduler &, void *stack = nullptr);
+
+  void *stack;
+  Scheduler &scheduler;
+  bool runnable = true;
+
+  /// Thread ID; will be automatically assigned.
+  unsigned tid;
+};
+
+extern "C" {
+/// This is a free function with C linkage as it is called via asm
+/// code. This code is injected at each thread's startup so
+/// bookkeeping tasks can be done (e.g., recording context switch
+/// times).
+///
+/// This shouldn't need to do anything with the thunk, it's just
+/// provided since it's conveniently available.
+void on_thread_start(KernelThread *, void (*thunk)());
+}
+
+class Scheduler {
+public:
+  /// Enter the scheduler. This should be called in live but doesn't
+  /// need to be called when unit-testing scheduler functionality.
+  void bootstrap();
+
+  /// \brief Select the next runnable process in round-robin order, and
+  /// actually switch stacks.
+  ///
+  /// This will throw if there are no schedulable tasks remaining.
+  void schedule();
+
+  /// Create a new thread that will start execution at the given
+  /// thunk.
+  void new_thread(void (*thunk)());
+
+  /// Print scheduler stats, for debugging purposes.
+  void print_stats() const;
+
+  /// \brief Destroy a thread.
+  ///
+  /// If the provided thread is not the running thread, then it is
+  /// destroyed immediately. If it is the running thread, then we
+  /// schedule away and defer the deletion until after scheduling
+  /// away.
+  ///
+  /// Note that there are no safeguards against destroying all
+  /// runnable threads such that there are no schedulable threads
+  /// remaining.
+  ///
+  /// \param thread the thread to destroy, or nullptr to destroy the
+  /// currently-running thread.
+  void destroy_thread(KernelThread *thread = nullptr);
+
+private:
+  KernelThread *running = nullptr;
+  util::IntrusiveListHead<KernelThread> runnable;
+  util::IntrusiveListHead<KernelThread> blocked;
+
+  KernelThread *pending_deletion = nullptr;
+
+  /// \brief Returns a runnable task to schedule next.
+  ///
+  /// \return thread to schedule. This should be non-null if there is
+  /// a dummy (always-schedulable) thread present.
+  const KernelThread *choose_task() const;
+
+  /// \brief Post-context switch bookkeeping actions.
+  ///
+  /// These are performed after switching stacks to the new task, so
+  /// they are performed in the context of the new task. However, this
+  /// should only update bookkeeping for the scheduler as a whole --
+  /// any bookkeeping specific to the context switch should have been
+  /// done _before_ the context switch.
+  ///
+  /// Currently, this performs the following tasks:
+  /// - Updates \ref context_switch_count and \ref
+  ///   context_switch_cum_cycles.
+  /// - Performs any pending thread deletions (since we can't delete
+  ///   the thread's stack+descriptor until after we've switched away
+  ///   from it.)
+  /// - Periodically print scheduler stats.
+  void post_context_switch_bookkeeping();
+
+  /// \brief Delete a thread that's not in use.
+  ///
+  /// This is the internal logic to free all the necessary data
+  /// structures; external clients should call `destroy_thread()` to
+  /// safely delete a task.
+  void delete_task(KernelThread *thread);
+
+  /// \brief Number of calls to `schedule()`.
+  ///
+  /// Currently, this doesn't count context switches from a function
+  /// to itself. This does count context switches to newly-created
+  /// threads.
+  unsigned context_switch_count = 0;
+
+  /// \brief Cumulative cycles (as counted by TSC) for all context
+  /// switches.
+  ///
+  /// This currently only counts the cycles spent in the stack switch,
+  /// for all context switches counted by \ref context_switch_count.
+  uint64_t context_switch_cum_cycles = 0;
+  uint64_t context_switch_start;
+
+  friend void ::sched::on_thread_start(KernelThread *, void (*)());
+};
+
+} // namespace sched

--- a/src/kernel/sched/kthread.h
+++ b/src/kernel/sched/kthread.h
@@ -1,11 +1,18 @@
 #pragma once
 
 /// \file
-/// \brief Kernel thread implementation
+/// \brief Kernel thread and thread scheduler implementation
 ///
-/// Each kernel thread gets a 4KB stack.
+/// The general interface for the scheduler is:
+/// - `Scheduler::bootstrap()`: register the current thread in the
+///   scheduler.
+/// - `Scheduler::new_thread(thunk)`: add a new task that will start
+///   executing `thunk`. This will be given a 4KB stack.
+/// - `Scheduler::destroy_thread()`: destroy the current running
+///   thread, and schedule away.
+/// - `Scheduler::schedule()`: context-switch to the next runnable
+///   task in a round-robin manner.
 ///
-/// TODO: more description
 /// TODO: pre-emptive scheduling (timer interrupt) and synchronization
 /// primitives
 

--- a/src/kernel/util/assert.h
+++ b/src/kernel/util/assert.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "perf.h"
 #include <cassert>
 
 /// \file
@@ -12,7 +13,7 @@
 ///
 /// The extra pair of parens is due to `assert` failing to accept an
 /// argument with commas.
-#define ASSERT(...) assert((__VA_ARGS__))
+#define ASSERT(...) assert(likely(__VA_ARGS__))
 
 /// \brief Compile-out debug macro in non-debug builds.
 ///

--- a/src/test/nonstd/test_crt.cc
+++ b/src/test/nonstd/test_crt.cc
@@ -20,7 +20,6 @@ __attribute__((constructor)) void foo() { a = 2; }
 
 } // namespace
 
-// NOCOMMIT: this is broken and I don't really want to fix it.
 TEST(nonstd::cpp, global_ctor) {
   TEST_ASSERT(a == 2);
   TEST_ASSERT(b == 3);

--- a/src/test/nonstd/test_crt.cc
+++ b/src/test/nonstd/test_crt.cc
@@ -20,6 +20,7 @@ __attribute__((constructor)) void foo() { a = 2; }
 
 } // namespace
 
+// NOCOMMIT: this is broken and I don't really want to fix it.
 TEST(nonstd::cpp, global_ctor) {
   TEST_ASSERT(a == 2);
   TEST_ASSERT(b == 3);

--- a/src/test/nonstd/test_string_view.cc
+++ b/src/test/nonstd/test_string_view.cc
@@ -69,6 +69,30 @@ TEST_CLASS(nonstd, string_view, substr) {
   static_assert("hello"_sv.substr(-1, string_view::npos) == "hello"_sv);
 }
 
+TEST_CLASS(nonstd, string_view, cmp) {
+  static_assert("abcd"_sv == "abcd"_sv);
+  static_assert("abcd"_sv <= "abcd"_sv);
+  static_assert("abcd"_sv >= "abcd"_sv);
+  static_assert(!("abcd"_sv < "abcd"_sv));
+  static_assert(!("abcd"_sv > "abcd"_sv));
+
+  static_assert("abcd"_sv != "abdc"_sv);
+
+  static_assert("abcd"_sv < "abcde"_sv);
+  static_assert("abcd"_sv <= "abcde"_sv);
+  static_assert(!("abcd"_sv >= "abcde"_sv));
+  static_assert("abcd"_sv != "abcde"_sv);
+
+  static_assert("abcde"_sv > "abcd"_sv);
+  static_assert("abcde"_sv >= "abcd"_sv);
+
+  static_assert("abcd"_sv < "efgh"_sv);
+  static_assert("abcd"_sv <= "efgh"_sv);
+
+  static_assert("efgh"_sv > "abcd"_sv);
+  static_assert("efgh"_sv >= "abcd"_sv);
+}
+
 TEST_CLASS(nonstd, string_view, non_constexpr) {
   char const *str1 = "hello";
   char const str2[] = "world!";

--- a/src/test/sched/test_kthread.cc
+++ b/src/test/sched/test_kthread.cc
@@ -1,0 +1,47 @@
+#include "../test.h"
+#include "sched/kthread.h"
+
+/// @file Test scheduler round-robin selection.
+///
+/// This file doesn't test the actual stack-switching behavior, which
+/// is is only a few lines and is exercised on each context switch.
+
+namespace sched {
+class TestScheduler : public Scheduler {
+public:
+  unsigned num_threads() const {
+    return !!running + runnable.size() + blocked.size();
+  }
+
+  ThreadID get_running_tid() const {
+    return running ? running->tid : bad_thread;
+  }
+
+  ThreadID choose_task_tid() const {
+    if (auto thread = choose_task()) {
+      return thread->tid;
+    }
+    return bad_thread;
+  }
+};
+} // namespace sched
+
+TEST_CLASS(sched, Scheduler, one_runnable_thread) {
+  TestScheduler scheduler;
+  unsigned tid0 = scheduler.bootstrap();
+
+  TEST_ASSERT(scheduler.num_threads() == 1);
+  TEST_ASSERT(scheduler.get_running_tid() == tid0);
+  TEST_ASSERT(scheduler.choose_task_tid() == tid0);
+
+  scheduler.schedule(false);
+
+  TEST_ASSERT(scheduler.num_threads() == 1);
+  TEST_ASSERT(scheduler.get_running_tid() == tid0);
+  TEST_ASSERT(scheduler.choose_task_tid() == tid0);
+}
+
+// NOCOMMIT:
+// TODO: multiple runnable threads (including some blocked threads)
+// TODO: round-robin
+// TODO: round-robin with deletes/adds

--- a/src/test/test.cc
+++ b/src/test/test.cc
@@ -3,7 +3,6 @@
 #include "nonstd/string_view.h"
 #include <algorithm>
 
-// NOCOMMIT: these should be const
 extern test::detail::TestInfo __start_data_test_info;
 extern test::detail::TestInfo __stop_data_test_info;
 
@@ -53,13 +52,7 @@ bool run(const detail::TestInfo *test) {
 void run_tests(const char *test_selection) {
   nonstd::printf("TEST SELECTION=%s\r\n", test_selection);
 
-  std::sort(&__start_data_test_info, &__stop_data_test_info,
-            [](const auto &test1, const auto &test2) {
-              // note: unsafe strcmp. should convert to
-              // nonstd::string_view and implement comparison
-              // operator there.
-              return nonstd::strcmp(test1.name, test2.name) < 0;
-            });
+  std::sort(&__start_data_test_info, &__stop_data_test_info);
 
   unsigned tests_run = 0, tests_passed = 0;
   for (const detail::TestInfo *test_info = &__start_data_test_info;

--- a/src/test/test.cc
+++ b/src/test/test.cc
@@ -1,9 +1,11 @@
 #include "test.h"
 #include "nonstd/libc.h"
 #include "nonstd/string_view.h"
+#include <algorithm>
 
-extern const test::detail::TestInfo __start_rodata_test_info;
-extern const test::detail::TestInfo __stop_rodata_test_info;
+// NOCOMMIT: these should be const
+extern test::detail::TestInfo __start_data_test_info;
+extern test::detail::TestInfo __stop_data_test_info;
 
 namespace test {
 
@@ -51,9 +53,17 @@ bool run(const detail::TestInfo *test) {
 void run_tests(const char *test_selection) {
   nonstd::printf("TEST SELECTION=%s\r\n", test_selection);
 
+  std::sort(&__start_data_test_info, &__stop_data_test_info,
+            [](const auto &test1, const auto &test2) {
+              // note: unsafe strcmp. should convert to
+              // nonstd::string_view and implement comparison
+              // operator there.
+              return nonstd::strcmp(test1.name, test2.name) < 0;
+            });
+
   unsigned tests_run = 0, tests_passed = 0;
-  for (const detail::TestInfo *test_info = &__start_rodata_test_info;
-       test_info != &__stop_rodata_test_info; ++test_info) {
+  for (const detail::TestInfo *test_info = &__start_data_test_info;
+       test_info != &__stop_data_test_info; ++test_info) {
     if (detail::matches(test_info->name, test_selection)) {
       ++tests_run;
       tests_passed += run(test_info);

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -64,6 +64,11 @@ struct TestInfo {
   // This takes a bool& argument rather than returning a bool so that
   // test doesn't have to explicitly return true.
   void (*fn)(bool &success);
+
+  // Sort tests by name.
+  auto operator<=>(const TestInfo &rhs) const {
+    return nonstd::string_view{name} <=> rhs.name;
+  }
 } __attribute__((packed));
 
 /// \brief Test selection logic. Only exposed for unit testing.

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -12,7 +12,7 @@
 ///         TEST_ASSERT(1 == 2);
 ///     }
 ///
-/// Test descriptors are placed in their own special rodata section
+/// Test descriptors are placed in their own special data section
 /// for automatic discovery.
 ///
 /// Tests are not built into the main kernel, but rather into a
@@ -81,7 +81,7 @@ bool matches(nonstd::string_view test_name, nonstd::string_view test_selection);
   }                                                                            \
   namespace {                                                                  \
   __attribute__((                                                              \
-      section("rodata_test_info"),                                             \
+      section("data_test_info"),                                               \
       used)) volatile test::detail::TestInfo test_info_##TEST_NAME_SYM{        \
       .name = #TEST_NS "::" #TEST_NAME_STR,                                    \
       .fn = &TEST_NS::test::TEST_NAME_SYM,                                     \
@@ -104,7 +104,7 @@ bool matches(nonstd::string_view test_name, nonstd::string_view test_selection);
   }                                                                            \
   namespace {                                                                  \
   __attribute__((                                                              \
-      section("rodata_test_info"),                                             \
+      section("data_test_info"),                                               \
       used)) volatile test::detail::TestInfo test_info_##TEST_NAME_SYM{        \
       .name = #TEST_NS "::" #TEST_NAME_STR,                                    \
       .fn = &TEST_NS::test::TEST_NAME_SYM,                                     \


### PR DESCRIPTION
This implements very basic thread management and scheduling. Each thread comprises a 4KB stack and a `KernelThread` descriptor. These are managed by a round-robin scheduler. Currently there are no synchronization primitives and scheduling is purely cooperative -- pre-emptive scheduling will be added in a later commit.

We keep track of some very basic statistics in the scheduler (number of context switches, cycles per context switch).

A very basic `kmalloc`/`kfree`/`new`/`delete` interface comprising a sequential arena is introduced here, since the slab allocator isn't implemented yet.